### PR TITLE
fix: secure isn't set on localhost when samesite is present

### DIFF
--- a/set-cookie.ts
+++ b/set-cookie.ts
@@ -84,8 +84,8 @@ export function setCookie(
     attrs.push(['Path', path]);
   }
 
-  // Always secure, except for localhost
-  if (origin && origin.hostname !== 'localhost')
+  // Always secure when isn't localhost or samesite is set
+  if (origin?.hostname !== 'localhost' || sameSite !== undefined)
     attrs.push(['Secure']);
 
   if (opts.httpOnly)


### PR DESCRIPTION
`Secure` attribute must always be set when `SameSite` attribute is present, else the cookie would be invalid.